### PR TITLE
Use `cid` from context when getting browser name

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -16,15 +16,15 @@
  * Currently, the test-related service messages cannot be output with Ant's echo task until flowId attribute is specified.
  */
 
-const { camelCase, get } = require('lodash');
+const { camelCase, get, invoke } = require('lodash');
 
 const paths = {
-  browser: 'runner.0.browserName',
-  details: 'err.stack',
-  flowId: 'specHash',
-  hash: 'specHash',
-  message: 'err.message',
-  title: 'title',
+  browser: ({ cid }) => ['runner', cid, 'browserName'],
+  details: () => 'err.stack',
+  flowId: () => 'specHash',
+  hash: () => 'specHash',
+  message: () => 'err.message',
+  title: () => 'title',
 };
 
 const events = {
@@ -100,7 +100,7 @@ function escape(str) {
  * @return {string}
  */
 function formatProp(prop, ctx) {
-  var value = get(ctx, paths[prop] || '', '');
+  var value = get(ctx, invoke(paths, prop, ctx), '');
 
   if (prop === 'message') {
     value = value.split('\n')[0];


### PR DESCRIPTION
The `[browser]` parameter for the TeamCity `name` property was not being filled in in my case. Upon inspection the reason is that the session isn't always at `ctx.runner['0']`, it is `ctx.runner[ctx.cid]`.

Example `ctx`:
```js
{ type: 'test:end',
  title: 'c',
  parent: '<name>',
  pending: false,
  file: '<path>.js',
  cid: '1a',
  specs: [ '<path>.js' ],
  event: 'test:end',
  runner: { '1a': { browserName: 'internet explorer' } },
  specHash: '<hash>' }
```
