### PR TITLE
Changing the "message" browser handling

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -19,7 +19,7 @@
 const { camelCase, get, invoke } = require('lodash');
 
 const paths = {
-  browser: ({ suite }) => ['suite', 'runner', suite.cid, 'browserName'],
+  browser: ({ suite }) => ['suite', 'runner', suite.cid, 'browser'],
   details: () => 'suite.err.stack',
   flowId: ({ suite }) => ['reporter', 'baseReporter', 'stats', 'runners', suite.cid, 'sessionID'],
   hash: () => 'suite.specHash',
@@ -99,7 +99,7 @@ function escape(str) {
  * @param  {string} ctx.event
  * @param  {object} ctx.runner
  * @param  {object} ctx.runner.0
- * @param  {string} ctx.runner.0.browserName
+ * @param  {string} ctx.runner.0.browser
  * @param  {string} ctx.specHash
  * @return {string}
  */


### PR DESCRIPTION
For BrowserStack test reporting the previously used "browserName" does not work. Had to change to it "browser" and now the name of the browser is displayed in the message.