### PR TITLE
Add uid path

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -25,6 +25,7 @@ const paths = {
   hash: () => 'suite.specHash',
   message: () => 'suite.err.message',
   title: () => 'suite.title',
+  uid: () => 'suite.uid',
 };
 
 const events = {


### PR DESCRIPTION
Adding UID path allows to get unique messages usable for [reporting test metadata](https://confluence.jetbrains.com/display/TCD18/Reporting+Test+Metadata), which requires uniqueness.