### PR TITLE
Fix: "Test failing in `beforeEach` is not reported as failed"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ notifications:
 
 language: node_js
 node_js:
-  - "8"
+  - "14"

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ class WdioTeamcityReporter extends WdioReporter {
   /**
    * @param {HookStats} hookStats
    */
-  onHookEnd(hookStats) {
+  onHookEnd (hookStats) {
     if (hookStats.state === 'failed') {
       this._m('##teamcity[testFailed name=\'{name}\' message=\'{error}\' details=\'{stack}\' flowId=\'{id}\']', hookStats)
     }
@@ -149,13 +149,13 @@ class WdioTeamcityReporter extends WdioReporter {
    * @param {SuiteStats} suiteStats
    */
   onSuiteEnd (suiteStats) {
-    const pendingTests = Object.values(suiteStats.tests).filter(test => test.state === 'pending');
+    const pendingTests = Object.values(suiteStats.tests).filter(test => test.state === 'pending')
     pendingTests.forEach(testStat => {
       testStat.error = testStat.error || {
         message: '',
         stack: ''
       }
-      this._m('##teamcity[testFailed name=\'{name}\' message=\'{error}\' details=\'{stack}\' flowId=\'{id}\']', testStat);
+      this._m('##teamcity[testFailed name=\'{name}\' message=\'{error}\' details=\'{stack}\' flowId=\'{id}\']', testStat)
     })
 
     this._m('##teamcity[testSuiteFinished name=\'{name}\' flowId=\'{id}\']', suiteStats)

--- a/index.js
+++ b/index.js
@@ -33,6 +33,21 @@ const assert = require('assert')
  * @property {string} [end]
  */
 
+/**
+ * @typedef {Object} HookStats
+ * @property {string} type
+ * @property {string} start
+ * @property {number} _duration
+ * @property {string} uid
+ * @property {string} cid
+ * @property {string} title
+ * @property {string} fullTitle
+ * @property {Array} output
+ * @property {any} argument
+ * @property {string} state
+ * @property {string} [end]
+ */
+
 class WdioTeamcityReporter extends WdioReporter {
   static escape (str) {
     if (!str) return ''
@@ -115,6 +130,15 @@ class WdioTeamcityReporter extends WdioReporter {
   }
 
   /**
+   * @param {HookStats} hookStats
+   */
+  onHookEnd(hookStats) {
+    if (hookStats.state === 'failed') {
+      this._m('##teamcity[testFailed name=\'{name}\' message=\'{error}\' details=\'{stack}\' flowId=\'{id}\']', hookStats)
+    }
+  }
+
+  /**
    * @param {TestStats} testStats
    */
   onTestSkip (testStats) {
@@ -125,6 +149,15 @@ class WdioTeamcityReporter extends WdioReporter {
    * @param {SuiteStats} suiteStats
    */
   onSuiteEnd (suiteStats) {
+    const pendingTests = Object.values(suiteStats.tests).filter(test => test.state === 'pending');
+    pendingTests.forEach(testStat => {
+      testStat.error = testStat.error || {
+        message: '',
+        stack: ''
+      }
+      this._m('##teamcity[testFailed name=\'{name}\' message=\'{error}\' details=\'{stack}\' flowId=\'{id}\']', testStat);
+    })
+
     this._m('##teamcity[testSuiteFinished name=\'{name}\' flowId=\'{id}\']', suiteStats)
   }
 

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ class WdioTeamcityReporter extends WdioReporter {
     const pendingTests = Object.values(suiteStats.tests).filter(test => test.state === 'pending')
     pendingTests.forEach(testStat => {
       testStat.error = testStat.error || {
-        message: '',
+        message: 'Test is considered as failed, as it is still "pending" on suite end.',
         stack: ''
       }
       this._m('##teamcity[testFailed name=\'{name}\' message=\'{error}\' details=\'{stack}\' flowId=\'{id}\']', testStat)

--- a/test/integration/fail.js
+++ b/test/integration/fail.js
@@ -14,3 +14,14 @@ suite('simple exception', () => {
     assert.strictEqual(browser.$('body').getAttribute('non-existing-attribute'), null)
   })
 })
+
+suite('exception in hook', () => {
+  setup(() => {
+    browser.url('https://www.google.ru/')
+    assert.strictEqual(browser.$('body').getAttribute('non-existing-attribute'), null)
+  })
+
+  test('failed in setup-hook', () => {
+    assert.strictEqual(browser.$('body').getAttribute('non-existing-attribute'), null)
+  })
+})


### PR DESCRIPTION
See issue https://github.com/sullenor/wdio-teamcity-reporter/issues/21 

This PR makes the reporter:
* report failed hooks as failed tests
* report tests pending on suite end as failed

This leads to, that errors in fx `beforeEach` or `afterEach` hooks are properly visible in the TeamCity UI.